### PR TITLE
Hotfixes

### DIFF
--- a/src/Servers/GameTrafficRelay/src/Entity/ConnectionListener.cs
+++ b/src/Servers/GameTrafficRelay/src/Entity/ConnectionListener.cs
@@ -93,7 +93,7 @@ namespace UniSpy.Server.GameTrafficRelay.Aggregate
                 return;
             }
             LogWriter.LogDebug($"[{ListeningEndPoint}] => [{GameSpyClientIPEndPoint}]  {StringExtensions.ConvertPrintableBytesToString(data)} [{StringExtensions.ConvertByteToHexString(data)}]");
-            SendAsync(GameSpyClientIPEndPoint, data);
+            Send(GameSpyClientIPEndPoint, data);
         }
 
         void IConnectionListener.Dispose()

--- a/src/Servers/NatNegotiation/src/Aggregate/Redis/NatAddressInfo.cs
+++ b/src/Servers/NatNegotiation/src/Aggregate/Redis/NatAddressInfo.cs
@@ -104,6 +104,10 @@ namespace UniSpy.Server.NatNegotiation.Aggregate.Redis
 
         public NatInitInfo(List<NatAddressInfo> infos)
         {
+            if (infos.Count == 0)
+            {
+                throw new NatNegotiation.Exception("Missing NatAddressInfo");
+            }
             AddressInfos = infos.Select((i) => new { i }).ToDictionary(a => ((NatPortType)a.i.PortType), a => a.i);
             if (infos.First().Version == 2)
             {


### PR DESCRIPTION
Some NAT hotfixes to address some random exceptions occurring such as:
 - `System.InvalidOperationException: Sequence contains no elements` _(NatAddressInfo.cs)_
 - `System.InvalidOperationException: An asynchronous socket operation is already in progress using this SocketAsyncEventArgs instance.` _(ConnectionListener.cs)_